### PR TITLE
account lockout

### DIFF
--- a/backend/database/models/user.js
+++ b/backend/database/models/user.js
@@ -16,7 +16,9 @@ const userSchema = new Schema({
 	transaction_ids: { type: String, unique: false, required: false},
 	good_color: { type: String, unique: false, required: false},
 	bad_color: { type: String, unique: false, required: false},
-	dark_mode: { type: Boolean },
+  dark_mode: { type: Boolean },
+  count: { type: Number, unique: false, required: false},
+  lockoutDate: { type: Date, unique: false, required: false},
 }, { collection: "Users"})
 
 // Define schema methods

--- a/backend/passport/LocalStrategy.js
+++ b/backend/passport/LocalStrategy.js
@@ -16,7 +16,33 @@ const strategy = new LocalStrategy(
 				return done(null, false, { message: 'Incorrect username' })
 			}
 			if (!user.checkPassword(password)) {
+				if (user.count == null) {
+					User.updateOne({username: user.username}, {count: 0, lockoutDate: new Date()}, (err, user) => {}).exec();
+				}
+
+				if (user.count >= 3) {
+					var date = new Date()
+					date.setMinutes(date.getMinutes() + 30);
+					User.updateOne({username: user.username}, {lockoutDate: date}, (err, user) => {}).exec();
+					return done(null, false, { message: 'Too many login attempts' })	
+				}
+
+
+				User.updateOne({username: user.username}, {count: user.count + 1}, (err, user) => {}).exec();
 				return done(null, false, { message: 'Incorrect password' })
+			}
+			if (user.count >= 3) {
+				var date = new Date()
+				//console.log(date)
+				//console.log(user.lockoutDate)
+				//console.log(date > user.lockoutDate)
+					if (date > user.lockoutDate) {
+						User.updateOne({username: user.username}, {count: 0}, (err, user) => {}).exec();
+						return done(null, user)
+					}
+					else {
+						return done(null, false, { message: 'Too many login attempts' })
+					}
 			}
 			return done(null, user)
 		})


### PR DESCRIPTION
lockout account on 4th incorrect attempt for 30 minutes, uses database for persistence. If another incorrect attempt is entered, timer is reset. User cannot abuse this to continually test passwords as they always receive same "unauthorized" response.